### PR TITLE
Fix CSS parsing failed: invalid color dim (#1)

### DIFF
--- a/terminal-buddy/terminal_buddy/app.py
+++ b/terminal-buddy/terminal_buddy/app.py
@@ -157,7 +157,7 @@ Screen {
 
 #message-log {
     height: 8;
-    border: solid dim;
+    border: solid grey;
 }
 """
 


### PR DESCRIPTION
## Changes

Replace invalid Textual CSS color dim with grey in #message-log border.

Fixes #1