### PR TITLE
fix: resolve BoundAnimator TypeError on startup

### DIFF
--- a/terminal-buddy/terminal_buddy/app.py
+++ b/terminal-buddy/terminal_buddy/app.py
@@ -196,7 +196,7 @@ Screen {
             self.push_screen(NewPetScreen(), self._on_new_pet_result)
         else:
             self._update_display()
-        self.set_interval(0.8, self._animate)
+        self.set_interval(0.8, self._animation_tick)
 
     def _on_new_pet_result(self, result):
         if result:
@@ -209,7 +209,7 @@ Screen {
                 self._log_message(msg)
         elif not self.pets:
             self.exit()
-    def _animate(self):
+    def _animation_tick(self):
         if self.pets:
             pet_display = self.query_one("#pet-display", PetDisplay)
             if pet_display.renderer:


### PR DESCRIPTION
## 修复内容
修复 terminal-buddy 启动时的 BoundAnimator TypeError 错误。

## 问题原因
Textual 框架内部使用 _animate 属性返回 BoundAnimator 对象。当 TerminalBuddyApp 类中定义 _animate 方法时，会与 Textual 内部属性冲突，导致调用 self._animate() 时实际上调用了 Textual 的 nimate() 方法。

## 解决方案
将 _animate 方法重命名为 _animation_tick，避免命名冲突。

## 测试
- 本地安装验证通过
- Import 测试通过

Closes #3
